### PR TITLE
Update Makefile.osx

### DIFF
--- a/src/makefiles/Makefile.osx
+++ b/src/makefiles/Makefile.osx
@@ -1,5 +1,4 @@
 CC=gcc
-ARCH=-arch i386 -arch x86_64 -arch ppc
 SOURCE=args.c \
         avra.c \
         coff.c \
@@ -14,5 +13,5 @@ SOURCE=args.c \
         stdextra.c
 
 all:
-	$(CC) $(ARCH) -o avra $(SOURCE)
+	$(CC) $(CDEFS) -o avra $(SOURCE)
 


### PR DESCRIPTION
- Archs other than 64-bit intel have been deprecated for ages, and removed in macOS 10.13 and later.
- `CDEFS` is ignored by the macOS makefile, meaning it simply fails to build currently