### PR TITLE
Make makefile more packaging friendly

### DIFF
--- a/src/makefiles/Makefile.linux
+++ b/src/makefiles/Makefile.linux
@@ -1,7 +1,7 @@
-CC = gcc
-LD = gcc -static
-CFLAGS = -Wall -O3 $(CDEFS)
-LDFLAGS = -s
+CC ?= gcc
+CFLAGS ?= -Wall -O3
+CFLAGS += $(CDEFS)
+LDFLAGS ?= -s
 
 SOURCES = avra.c \
 	device.c \
@@ -19,7 +19,7 @@ SOURCES = avra.c \
 OBJECTS = $(SOURCES:.c=.o)
 
 avra: $(OBJECTS)
-	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)
+	$(CC) -o $@ $(OBJECTS) $(LDFLAGS)
 
 clean:
 	rm -f avra *.o *.p *~


### PR DESCRIPTION
- Respect CC/CFLAGS/LDFLAGS set in the environment (by user or by build system)
- Use CC as a linker, avoid unneeded static linking

This may as well fix #6