### PR TITLE
Allow to override PREFIX and include directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ DISTFILES = src \
 	COPYING \
 	Makefile \
 
-PREFIX = /usr/local
-TARGET_INCLUDE_PATH = $(PREFIX)/include/avr
+PREFIX ?= /usr/local
+TARGET_INCLUDE_PATH ?= $(PREFIX)/include/avr
 
 CDEFS = -DDEFAULT_INCLUDE_PATH='"$(TARGET_INCLUDE_PATH)"' \
 	-DVERSION='"$(VERSION)"'


### PR DESCRIPTION
This is required for packaging as well.

PS. Are you sure it is correct to use `PREFIX/include` by default? The directory is meant for native C/C++ includes, while these are assembly avra-specific includes. I'd place them into `${PREFIX}/share/avra/includes` instead, that's what FreeBSD port of older avra (1.3.0) which I'm working on an update for did.